### PR TITLE
Consider updating to Redux 1.0 RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "repository": "https://github.com/suin/redux-multiple-reducers-example",
   "dependencies": {
     "react": "^0.13.3",
-    "redux": "^1.0.0-alpha"
+    "react-redux": "^0.2.1",
+    "redux": "^1.0.0-rc",
+    "redux-thunk": "^0.1.0"
   },
   "devDependencies": {
     "babel-core": "^5.6.18",

--- a/src/js/views/components/Counter1.js
+++ b/src/js/views/components/Counter1.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {bindActionCreators} from "redux";
-import {connect} from "redux/react";
+import {connect} from "react-redux";
 
 import * as counter1Actions from "actions/counter1Actions";
 

--- a/src/js/views/components/Counter2.js
+++ b/src/js/views/components/Counter2.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {bindActionCreators} from "redux";
-import {connect} from "redux/react";
+import {connect} from "react-redux";
 
 import * as counter2Actions from "actions/counter2Actions";
 

--- a/src/js/views/containers/App.js
+++ b/src/js/views/containers/App.js
@@ -1,11 +1,14 @@
 import React from "react";
-import {createStore} from "redux";
-import {Provider} from "redux/react";
+import {createStore, combineReducers, applyMiddleware} from "redux";
+import {Provider} from "react-redux";
+import thunk from "redux-thunk";
 
 import * as reducers from "reducers";
 import CounterApp from "views/containers/CounterApp";
 
-const store = createStore(reducers);
+const reducer = combineReducers(reducers);
+const finalCreateStore = applyMiddleware(thunk)(createStore);
+const store = finalCreateStore(reducer);
 
 export default class App {
   render() {


### PR DESCRIPTION
Redux 1.0 RC is out with breaking changes. **No further API changes are expected in 1.0 so it may be a good time to port the example to 1.0 RC (in a branch).** We will release 1.0 when the docs are ready.

You can find the comprehensive list of the changes in 1.0 RC against 1.0 alpha in the **[Redux 1.0 RC release notes](https://github.com/gaearon/redux/releases/tag/v1.0.0-rc)**. If you haven't ported to alpha yet, you'll need to **[apply changes from 0.12 to alpha first](https://github.com/gaearon/redux/pull/195#issue-92206321)**.

Thank you!
Please make sure to report any issues so we can release a stable 1.0.
